### PR TITLE
pass around objects as info instead of gtypes

### DIFF
--- a/src/bindings/girepository.js
+++ b/src/bindings/girepository.js
@@ -26,6 +26,7 @@ const { g } = openLib(libName("girepository-1.0", 1), {
       get_name: $string($pointer),
       is_deprecated: $bool($pointer),
       get_type: $i32($pointer),
+      ref: $void($pointer),
       unref: $void($pointer),
     },
     constant_info: {

--- a/src/handleInfo.js
+++ b/src/handleInfo.js
@@ -3,7 +3,7 @@ import g from "./bindings/mod.js";
 import { handleCallable } from "./types/callable.js";
 import { createConstant } from "./types/constant.js";
 import { handleSignal } from "./types/signal.js";
-import { objectByGType } from "./utils/gobject.js";
+import { objectByInfo } from "./utils/gobject.js";
 import { getName } from "./utils/string.ts";
 
 export function handleInfo(target, info) {
@@ -16,10 +16,10 @@ export function handleInfo(target, info) {
     case GIInfoType.OBJECT:
     case GIInfoType.STRUCT:
     case GIInfoType.INTERFACE: {
-      const gType = g.registered_type_info.get_g_type(info);
+      g.base_info.ref(info);
       Object.defineProperty(target, name, {
         get() {
-          return objectByGType(gType);
+          return objectByInfo(info);
         },
       });
       break;

--- a/src/types/argument.js
+++ b/src/types/argument.js
@@ -8,7 +8,7 @@ import {
   deref_str,
 } from "../base_utils/convert.ts";
 import { ExtendedDataView } from "../utils/dataview.js";
-import { objectByGType } from "../utils/gobject.js";
+import { objectByInfo } from "../utils/gobject.js";
 import { boxArray, unboxArray } from "./argument/array.js";
 import { boxInterface, unboxInterface } from "./argument/interface.js";
 
@@ -18,8 +18,7 @@ export function initArgument(type) {
   switch (tag) {
     case GITypeTag.INTERFACE: {
       const info = g.type_info.get_interface(type);
-      const g_type = g.registered_type_info.get_g_type(info);
-      const o = objectByGType(g_type);
+      const o = objectByInfo(info);
       const v = new o();
       const result = cast_ptr_u64(Reflect.getOwnMetadata("gi:ref", v));
       g.base_info.unref(info);

--- a/src/utils/gobject.js
+++ b/src/utils/gobject.js
@@ -20,6 +20,20 @@ export function objectByGType(gType) {
   return result;
 }
 
+export function objectByInfo(info) {
+  const gType = g.registered_type_info.get_g_type(info);
+
+  // TODO: 4n is actually G_TYPE_VOID
+  if (gType !== 4n && cache.has(gType)) {
+    return cache.get(gType);
+  }
+
+  const result = createGObject(info, gType);
+  Object.freeze(result);
+  cache.set(gType, result);
+  return result;
+}
+
 function createGObject(info, gType) {
   const type = g.base_info.get_type(info);
 


### PR DESCRIPTION
this is because boxed types (structs and unions) don't usually have gtypes

and as hence utilising them will fail. the current approach necessities refing many typeinfos, but I don't see a way around that. It's also a good idea to make sure the old function is deleted (`objectByGType`) and `objectByInfo` is used everywhere instead.