### PR TITLE
Support overrides

### DIFF
--- a/src/base_utils/convert.ts
+++ b/src/base_utils/convert.ts
@@ -1,3 +1,4 @@
+import { ExtendedDataView } from "../utils/dataview.js";
 import type { TypedArray } from "./ffipp.js";
 
 const encoder = new TextEncoder();
@@ -45,4 +46,9 @@ export function deref_str(pointer: Deno.PointerValue, offset = 0) {
     pointer,
     offset,
   );
+}
+
+export function peek_ptr(pointer: Deno.PointerObject, offset = 0) {
+  return cast_u64_ptr(new ExtendedDataView(deref_buf(pointer, 8, offset))
+    .getBigUint64());
 }

--- a/src/bindings/girepository.js
+++ b/src/bindings/girepository.js
@@ -21,6 +21,7 @@ const { g } = openLib(libName("girepository-1.0", 1), {
       enumerate_versions: $pointer($pointer, $string),
       get_version: $string($pointer, $string),
       is_registered: $bool($pointer, $string, $string),
+      get_dependencies: $pointer($pointer, $string),
     },
     registered_type_info: {
       get_g_type: $i64($pointer),

--- a/src/gi.js
+++ b/src/gi.js
@@ -2,6 +2,7 @@ import { cast_u64_ptr, deref_buf, deref_str } from "./base_utils/convert.ts";
 import g from "./bindings/mod.js";
 import handleInfo from "./handleInfo.js";
 import { ExtendedDataView } from "./utils/dataview.js";
+import { loadOverride } from "./overrides/mod.ts";
 
 const repos = new Map();
 
@@ -93,6 +94,8 @@ export function require(namespace, version) {
     handleInfo(repo, info);
     g.base_info.unref(info);
   }
+
+  loadOverride(namespace, repo);
 
   repos.set(key, repo);
 

--- a/src/gi.js
+++ b/src/gi.js
@@ -2,7 +2,8 @@ import { cast_u64_ptr, deref_buf, deref_str } from "./base_utils/convert.ts";
 import g from "./bindings/mod.js";
 import handleInfo from "./handleInfo.js";
 import { ExtendedDataView } from "./utils/dataview.js";
-import { loadOverride } from "./overrides/mod.ts";
+import { hasOverride, loadOverride } from "./overrides/mod.ts";
+import { peek_ptr } from "./base_utils/convert.ts";
 
 const repos = new Map();
 
@@ -47,11 +48,19 @@ function getLatestVersion(namespace) {
  * @returns
  */
 export function require(namespace, version) {
+  // if no version is specified, the latest
   if (!version) {
     version = getLatestVersion(namespace);
   }
 
-  // if no version is specified, the latest
+  const repo = load(namespace, version);
+
+  loadDependencies(namespace, version);
+
+  return repo;
+}
+
+function load(namespace, version) {
   const key = `${namespace}-${version}`;
 
   if (repos.has(key)) {
@@ -100,4 +109,32 @@ export function require(namespace, version) {
   repos.set(key, repo);
 
   return repo;
+}
+
+function loadDependencies(namespace) {
+  const dependencies = get_cstr_array(
+    g.irepository.get_dependencies(null, namespace),
+  );
+
+  for (const dependency of dependencies) {
+    const [namespace, version] = dependency.split("-");
+
+    // only load dependencies that have overrides, as it saves time
+    // otherwise they will be loaded when required
+    if (hasOverride(namespace, version)) {
+      load(namespace, version);
+    }
+  }
+}
+
+function get_cstr_array(pointer) {
+  const strings = [];
+
+  for (let i = 0; true; i++) {
+    const str = deref_str(peek_ptr(pointer, i * 8));
+    if (!str) break;
+    strings.push(str);
+  }
+
+  return strings;
 }

--- a/src/overrides/GObject.ts
+++ b/src/overrides/GObject.ts
@@ -1,0 +1,68 @@
+// deno-lint-ignore-file no-explicit-any
+import { GConnectFlags } from "../bindings/enums.js";
+import g from "../bindings/mod.js";
+import { createCallback } from "../types/callback.js";
+
+type Handler = (...args: unknown[]) => unknown;
+
+function addObjectMethods(object: any) {
+  object.prototype.connect = function (
+    action: string,
+    callback: Handler,
+  ) {
+    const signalInfo = Reflect.getMetadata(
+      "gi:signals",
+      this.constructor,
+      action.split("::")[0],
+    );
+
+    const cb = createCallback(signalInfo, callback, this);
+    const handler = g.signal.connect_data(
+      Reflect.getOwnMetadata("gi:ref", this),
+      action,
+      cb.pointer,
+      null,
+      null,
+      GConnectFlags.SWAPPED,
+    );
+
+    return handler;
+  };
+
+  object.prototype.on = function (
+    action: string,
+    callback: Handler,
+  ) {
+    return this.connect(action, callback);
+  };
+
+  object.prototype.once = function (
+    action: string,
+    callback: Handler,
+  ) {
+    const handler = this.connect(action, (...args: unknown[]) => {
+      callback(...args);
+      this.off(handler);
+    });
+
+    return handler;
+  };
+
+  object.prototype.off = function (handler: Handler) {
+    g.signal.handler_disconnect(
+      Reflect.getOwnMetadata("gi:ref", this),
+      handler as any,
+    );
+  };
+
+  object.prototype.emit = function (action: string) {
+    g.signal.emit_by_name(
+      Reflect.getOwnMetadata("gi:ref", this),
+      action,
+    );
+  };
+}
+
+export function _init(GObject: any) {
+  addObjectMethods(GObject.Object);
+}

--- a/src/overrides/mod.ts
+++ b/src/overrides/mod.ts
@@ -1,0 +1,22 @@
+import * as GObject from "./GObject.ts";
+
+export interface GIOverride {
+  name: string;
+  version: string;
+  // deno-lint-ignore no-explicit-any
+  module: any;
+}
+
+export const overrides: GIOverride[] = [
+  { name: "GObject", version: "2.0", module: GObject },
+];
+
+export function loadOverride(namespace: string, repo: unknown) {
+  const override = overrides.find((override) => {
+    return override.name === namespace;
+  });
+
+  if (override) {
+    override.module._init(repo);
+  }
+}

--- a/src/overrides/mod.ts
+++ b/src/overrides/mod.ts
@@ -11,6 +11,12 @@ export const overrides: GIOverride[] = [
   { name: "GObject", version: "2.0", module: GObject },
 ];
 
+export function hasOverride(namespace: string, version: string) {
+  return overrides.some((override) => {
+    return override.name === namespace && override.version === version;
+  });
+}
+
 export function loadOverride(namespace: string, repo: unknown) {
   const override = overrides.find((override) => {
     return override.name === namespace;

--- a/src/types/object.js
+++ b/src/types/object.js
@@ -11,6 +11,7 @@ function getParentClass(info) {
 
   if (parent) {
     const gType = g.registered_type_info.get_g_type(parent);
+    g.base_info.unref(parent);
 
     const ParentClass = objectByGType(gType);
 

--- a/src/types/object.js
+++ b/src/types/object.js
@@ -2,22 +2,18 @@ import g from "../bindings/mod.js";
 import { getName } from "../utils/string.ts";
 import { handleCallable, handleStructCallable } from "./callable.js";
 import { objectByGType } from "../utils/gobject.js";
-import { GConnectFlags } from "../bindings/enums.js";
-import { createCallback } from "./callback.js";
 import { handleSignal } from "./signal.js";
 import { handleProp } from "./prop.js";
 
-function extendObject(target, info) {
+function getParentClass(info) {
   const parent = g.object_info.get_parent(info);
 
   if (parent) {
     const gType = g.registered_type_info.get_g_type(parent);
 
     const ParentClass = objectByGType(gType);
-    Object.setPrototypeOf(target.prototype, ParentClass.prototype);
-    //Object.assign(target.__signals__, ParentClass.__signals__);
 
-    g.base_info.unref(parent);
+    return ParentClass;
   }
 }
 
@@ -102,63 +98,18 @@ function defineClassStructMethods(target, info) {
 }
 
 export function createObject(info, gType) {
-  const ObjectClass = class {
-    constructor(props = {}) {
-      Reflect.defineMetadata("gi:ref", g.object.new(gType, null), this);
-      Object.entries(props).forEach(([key, value]) => {
-        this[key] = value;
-      });
-    }
+  const ParentClass = getParentClass(info) ?? Object;
 
-    connect(action, callback) {
-      const signalInfo = Reflect.getMetadata(
-        "gi:signals",
-        ObjectClass,
-        action.split("::")[0],
-      );
+  const ObjectClass = class extends ParentClass {
+    constructor(props = {}, init = true) {
+      super(props, false);
 
-      const cb = createCallback(signalInfo, callback, this);
-      const handler = g.signal.connect_data(
-        Reflect.getOwnMetadata("gi:ref", this),
-        action,
-        cb.pointer,
-        null,
-        null,
-        GConnectFlags.SWAPPED,
-      );
-
-      return handler;
-    }
-
-    disconnect(handler) {
-      g.signal.handler_disconnect(
-        Reflect.getOwnMetadata("gi:ref", this),
-        handler,
-      );
-    }
-
-    emit(action) {
-      g.signal.emit_by_name(
-        Reflect.getOwnMetadata("gi:ref", this),
-        action,
-      );
-    }
-
-    on(action, callback) {
-      return this.connect(action, callback);
-    }
-
-    once(action, callback) {
-      const handler = this.connect(action, (...args) => {
-        callback(...args);
-        this.off(handler);
-      });
-
-      return handler;
-    }
-
-    off(handler) {
-      return this.disconnect(handler);
+      if (init) {
+        Reflect.defineMetadata("gi:ref", g.object.new(gType, null), this);
+        Object.entries(props).forEach(([key, value]) => {
+          this[key] = value;
+        });
+      }
     }
   };
 
@@ -172,7 +123,6 @@ export function createObject(info, gType) {
   defineVFuncs(ObjectClass, info);
   defineSignals(ObjectClass, info);
   defineProps(ObjectClass, info);
-  extendObject(ObjectClass, info);
   inheritInterfaces(ObjectClass, info);
   defineClassStructMethods(ObjectClass, info);
 

--- a/src/utils/gobject.js
+++ b/src/utils/gobject.js
@@ -30,6 +30,13 @@ export function objectByGType(_gType) {
   }
 
   const info = g.irepository.find_by_gtype(null, gType);
+
+  if (!info) {
+    throw new Error(
+      `Could not find GObjectInfo for ${_gType}. Is it a valid registered type?`,
+    );
+  }
+
   const result = createGObject(info, gType);
   Object.freeze(result);
   cache.set(gType, result);

--- a/src/utils/gobject.js
+++ b/src/utils/gobject.js
@@ -1,4 +1,4 @@
-import { GIInfoType } from "../bindings/enums.js";
+import { GIInfoType, GType } from "../bindings/enums.js";
 import g from "../bindings/mod.js";
 import { createEnum } from "../types/enum.js";
 import { createInterface } from "../types/interface.js";
@@ -7,7 +7,24 @@ import { createStruct } from "../types/struct.js";
 
 export const cache = new Map();
 
-export function objectByGType(gType) {
+// find the closest registed parent type. sometimes gTypes may not be visible
+// in gobject-introspection for one of two reasons: 1. they were registered
+// as by the user as a static type or 2. the namespace they are in is not
+// loaded.
+function getBaseGType(gType) {
+  if (!g.type.is_a(gType, GType.OBJECT)) return gType;
+
+  let baseGType = gType;
+  while (!g.irepository.find_by_gtype(null, baseGType)) {
+    baseGType = g.type.parent(baseGType);
+  }
+
+  return baseGType;
+}
+
+export function objectByGType(_gType) {
+  const gType = getBaseGType(_gType);
+
   if (cache.has(gType)) {
     return cache.get(gType);
   }


### PR DESCRIPTION
also move gobject.object overrides to new file
allowing to construct objects by extending the existing object