### PR TITLE
Throw invoke errors

### DIFF
--- a/src/bindings/girepository.js
+++ b/src/bindings/girepository.js
@@ -18,6 +18,7 @@ const { g } = openLib(libName("girepository-1.0", 1), {
       get_n_infos: $i32($pointer, $string),
       get_info: $pointer($pointer, $string, $i32),
       find_by_gtype: $pointer($pointer, $i64),
+      find_by_name: $pointer($pointer, $string, $string),
     },
     registered_type_info: {
       get_g_type: $i64($pointer),

--- a/src/bindings/girepository.js
+++ b/src/bindings/girepository.js
@@ -18,7 +18,6 @@ const { g } = openLib(libName("girepository-1.0", 1), {
       get_n_infos: $i32($pointer, $string),
       get_info: $pointer($pointer, $string, $i32),
       find_by_gtype: $pointer($pointer, $i64),
-      find_by_name: $pointer($pointer, $string, $string),
     },
     registered_type_info: {
       get_g_type: $i64($pointer),

--- a/src/bindings/girepository.js
+++ b/src/bindings/girepository.js
@@ -18,6 +18,9 @@ const { g } = openLib(libName("girepository-1.0", 1), {
       get_n_infos: $i32($pointer, $string),
       get_info: $pointer($pointer, $string, $i32),
       find_by_gtype: $pointer($pointer, $i64),
+      enumerate_versions: $pointer($pointer, $string),
+      get_version: $string($pointer, $string),
+      is_registered: $bool($pointer, $string, $string),
     },
     registered_type_info: {
       get_g_type: $i64($pointer),

--- a/src/bindings/girepository.js
+++ b/src/bindings/girepository.js
@@ -14,7 +14,7 @@ import {
 const { g } = openLib(libName("girepository-1.0", 1), {
   g: {
     irepository: {
-      require: $void($pointer, $string, $string, $i32, $pointer),
+      require: $pointer($pointer, $string, $string, $i32, $buffer),
       get_n_infos: $i32($pointer, $string),
       get_info: $pointer($pointer, $string, $i32),
       find_by_gtype: $pointer($pointer, $i64),

--- a/src/bindings/girepository.js
+++ b/src/bindings/girepository.js
@@ -44,6 +44,7 @@ const { g } = openLib(libName("girepository-1.0", 1), {
     enum_info: {
       get_n_values: $i32($pointer),
       get_value: $pointer($pointer, $i32),
+      get_error_domain: $string($pointer),
     },
     value_info: {
       get_value: $i32($pointer),

--- a/src/bindings/glib.js
+++ b/src/bindings/glib.js
@@ -1,10 +1,14 @@
 import { libName, openLib } from "../base_utils/ffipp.js";
 
-import { $string, $u32 } from "../base_utils/types.ts";
+import { $pointer, $string, $u32 } from "../base_utils/types.ts";
 
 const { g } = openLib(libName("glib-2.0", 0), {
   g: {
     quark_from_string: $u32($string),
+    slist: {
+      length: $u32($pointer),
+      nth: $pointer($pointer, $u32),
+    },
   },
 });
 

--- a/src/bindings/glib.js
+++ b/src/bindings/glib.js
@@ -1,0 +1,11 @@
+import { libName, openLib } from "../base_utils/ffipp.js";
+
+import { $string, $u32 } from "../base_utils/types.ts";
+
+const { g } = openLib(libName("glib-2.0", 0), {
+  g: {
+    quark_from_string: $u32($string),
+  },
+});
+
+export default g;

--- a/src/bindings/mod.js
+++ b/src/bindings/mod.js
@@ -1,4 +1,5 @@
+import glib from "./glib.js";
 import gir from "./girepository.js";
 import gobject from "./gobject.js";
 
-export default { ...gir, ...gobject };
+export default { ...gir, ...gobject, ...glib };

--- a/src/gi.js
+++ b/src/gi.js
@@ -9,8 +9,10 @@ const repos = new Map();
  * @returns
  */
 export function require(namespace, version) {
-  if (repos.has(namespace)) {
-    return repos.get(namespace);
+  const key = `${namespace}-${version ?? ""}`;
+
+  if (repos.has(key)) {
+    return repos.get(key);
   }
 
   const repo = new Object();
@@ -31,7 +33,7 @@ export function require(namespace, version) {
     g.base_info.unref(info);
   }
 
-  repos.set(namespace, repo);
+  repos.set(key, repo);
 
   return repo;
 }

--- a/src/gi.js
+++ b/src/gi.js
@@ -1,12 +1,20 @@
 import g from "./bindings/mod.js";
 import handleInfo from "./handleInfo.js";
 
+const repos = new Map();
+
 /**
  * @param {string} namespace
  * @param {string?} version
  * @returns
  */
 export function require(namespace, version) {
+  const key = `${namespace}-${version ?? ""}`;
+
+  if (repos.has(key)) {
+    return repos.get(key);
+  }
+
   const repo = new Object();
 
   g.irepository.require(
@@ -24,6 +32,10 @@ export function require(namespace, version) {
     handleInfo(repo, info);
     g.base_info.unref(info);
   }
+
+  loadOverride(namespace, repo);
+
+  repos.set(key, repo);
 
   return repo;
 }

--- a/src/gi.js
+++ b/src/gi.js
@@ -1,7 +1,44 @@
+import { cast_u64_ptr, deref_buf, deref_str } from "./base_utils/convert.ts";
 import g from "./bindings/mod.js";
 import handleInfo from "./handleInfo.js";
+import { ExtendedDataView } from "./utils/dataview.js";
 
 const repos = new Map();
+
+function getLatestVersion(namespace) {
+  if (g.irepository.is_registered(null, namespace, null)) {
+    return g.irepository.get_version(null, namespace);
+  }
+
+  const versions = g.irepository.enumerate_versions(null, namespace);
+
+  // No versions are available, require will throw an error
+  if (!versions) return null;
+
+  const array = [];
+
+  for (let i = 0; i < g.slist.length(versions); i++) {
+    const version = g.slist.nth(versions, i);
+    const dataView = new ExtendedDataView(deref_buf(version, 8));
+    const pointer = cast_u64_ptr(dataView.getBigUint64());
+
+    array.push(deref_str(pointer));
+  }
+
+  if (array.length === 0) return null;
+
+  if (array.length > 1) {
+    console.warn(
+      `Requiring ${namespace} but it has ${array.length} versions available. Specify version to pick one.`,
+    );
+  }
+
+  return array
+    .sort((a, b) => {
+      return a.localeCompare(b, undefined, { numeric: true });
+    })
+    .reverse()[0];
+}
 
 /**
  * @param {string} namespace
@@ -9,7 +46,12 @@ const repos = new Map();
  * @returns
  */
 export function require(namespace, version) {
-  const key = `${namespace}-${version ?? ""}`;
+  if (!version) {
+    version = getLatestVersion(namespace);
+  }
+
+  // if no version is specified, the latest
+  const key = `${namespace}-${version}`;
 
   if (repos.has(key)) {
     return repos.get(key);

--- a/src/gi.js
+++ b/src/gi.js
@@ -9,10 +9,8 @@ const repos = new Map();
  * @returns
  */
 export function require(namespace, version) {
-  const key = `${namespace}-${version ?? ""}`;
-
-  if (repos.has(key)) {
-    return repos.get(key);
+  if (repos.has(namespace)) {
+    return repos.get(namespace);
   }
 
   const repo = new Object();
@@ -33,7 +31,7 @@ export function require(namespace, version) {
     g.base_info.unref(info);
   }
 
-  repos.set(key, repo);
+  repos.set(namespace, repo);
 
   return repo;
 }

--- a/src/gi.js
+++ b/src/gi.js
@@ -33,8 +33,6 @@ export function require(namespace, version) {
     g.base_info.unref(info);
   }
 
-  loadOverride(namespace, repo);
-
   repos.set(key, repo);
 
   return repo;

--- a/src/types/callable/constructor.js
+++ b/src/types/callable/constructor.js
@@ -24,6 +24,10 @@ export function createConstructor(info, prototype) {
     );
 
     if (!success) {
+      if (!error[0]) {
+        throw new Error(`Error invoking constructor ${getName(info)}`);
+      }
+
       throw createGError(error[0]);
     }
 

--- a/src/types/callable/constructor.js
+++ b/src/types/callable/constructor.js
@@ -10,7 +10,7 @@ export function createConstructor(info, prototype) {
   return (...args) => {
     const inArgs = parseInArgs(...args);
 
-    const error = new ArrayBuffer(8);
+    const error = new BigUint64Array(1);
     const returnValue = new ArrayBuffer(8);
 
     const success = g.function_info.invoke(
@@ -24,7 +24,7 @@ export function createConstructor(info, prototype) {
     );
 
     if (!success) {
-      throw createGError(error);
+      throw createGError(error[0]);
     }
 
     const result = Object.create(prototype);

--- a/src/types/callable/constructor.js
+++ b/src/types/callable/constructor.js
@@ -1,8 +1,7 @@
 import g from "../../bindings/mod.js";
 import { cast_u64_ptr } from "../../base_utils/convert.ts";
-import { gerrorToString } from "../../utils/error.ts";
+import { createGError } from "../../utils/error.ts";
 import { ExtendedDataView } from "../../utils/dataview.js";
-import { getName } from "../../utils/string.ts";
 import { parseCallableArgs } from "../callable.js";
 
 export function createConstructor(info, prototype) {
@@ -25,10 +24,7 @@ export function createConstructor(info, prototype) {
     );
 
     if (!success) {
-      console.error(
-        `Error invoking method ${getName(info)}:`,
-        gerrorToString(error),
-      );
+      throw createGError(error);
     }
 
     const result = Object.create(prototype);

--- a/src/types/callable/constructor.js
+++ b/src/types/callable/constructor.js
@@ -1,5 +1,6 @@
 import g from "../../bindings/mod.js";
 import { cast_u64_ptr } from "../../base_utils/convert.ts";
+import { gerrorToString } from "../../utils/error.ts";
 import { ExtendedDataView } from "../../utils/dataview.js";
 import { getName } from "../../utils/string.ts";
 import { parseCallableArgs } from "../callable.js";
@@ -24,7 +25,10 @@ export function createConstructor(info, prototype) {
     );
 
     if (!success) {
-      console.error(`Error invoking function ${getName(info)}`);
+      console.error(
+        `Error invoking method ${getName(info)}:`,
+        gerrorToString(error),
+      );
     }
 
     const result = Object.create(prototype);

--- a/src/types/callable/constructor.js
+++ b/src/types/callable/constructor.js
@@ -10,7 +10,7 @@ export function createConstructor(info, prototype) {
   return (...args) => {
     const inArgs = parseInArgs(...args);
 
-    const error = new ArrayBuffer(16);
+    const error = new ArrayBuffer(8);
     const returnValue = new ArrayBuffer(8);
 
     const success = g.function_info.invoke(

--- a/src/types/callable/function.js
+++ b/src/types/callable/function.js
@@ -1,7 +1,6 @@
 import { GITypeTag } from "../../bindings/enums.js";
 import g from "../../bindings/mod.js";
-import { gerrorToString } from "../../utils/error.ts";
-import { getName } from "../../utils/string.ts";
+import { createGError } from "../../utils/error.ts";
 import { unboxArgument } from "../argument.js";
 import { parseCallableArgs } from "../callable.js";
 
@@ -27,11 +26,7 @@ export function createFunction(info) {
     );
 
     if (!success) {
-      console.error(
-        `Error invoking method ${getName(info)}:`,
-        gerrorToString(error),
-      );
-      return;
+      throw createGError(error);
     }
 
     const retVal = unboxArgument(returnType, returnValue);

--- a/src/types/callable/function.js
+++ b/src/types/callable/function.js
@@ -1,5 +1,6 @@
 import { GITypeTag } from "../../bindings/enums.js";
 import g from "../../bindings/mod.js";
+import { gerrorToString } from "../../utils/error.ts";
 import { getName } from "../../utils/string.ts";
 import { unboxArgument } from "../argument.js";
 import { parseCallableArgs } from "../callable.js";
@@ -26,7 +27,10 @@ export function createFunction(info) {
     );
 
     if (!success) {
-      console.error(`Error invoking function ${getName(info)}`);
+      console.error(
+        `Error invoking method ${getName(info)}:`,
+        gerrorToString(error),
+      );
       return;
     }
 

--- a/src/types/callable/function.js
+++ b/src/types/callable/function.js
@@ -12,7 +12,7 @@ export function createFunction(info) {
     const inArgs = parseInArgs(...args);
     const outArgs = initOutArgs();
 
-    const error = new ArrayBuffer(16);
+    const error = new ArrayBuffer(8);
     const returnValue = new ArrayBuffer(8);
 
     const success = g.function_info.invoke(

--- a/src/types/callable/function.js
+++ b/src/types/callable/function.js
@@ -12,7 +12,7 @@ export function createFunction(info) {
     const inArgs = parseInArgs(...args);
     const outArgs = initOutArgs();
 
-    const error = new ArrayBuffer(8);
+    const error = new BigUint64Array(1);
     const returnValue = new ArrayBuffer(8);
 
     const success = g.function_info.invoke(
@@ -26,7 +26,7 @@ export function createFunction(info) {
     );
 
     if (!success) {
-      throw createGError(error);
+      throw createGError(error[0]);
     }
 
     const retVal = unboxArgument(returnType, returnValue);

--- a/src/types/callable/function.js
+++ b/src/types/callable/function.js
@@ -26,6 +26,10 @@ export function createFunction(info) {
     );
 
     if (!success) {
+      if (!error[0]) {
+        throw new Error(`Error invoking function ${getName(info)}`);
+      }
+
       throw createGError(error[0]);
     }
 

--- a/src/types/callable/method.js
+++ b/src/types/callable/method.js
@@ -15,7 +15,7 @@ export function createMethod(info) {
 
     inArgs.unshift(cast_ptr_u64(caller));
 
-    const error = new ArrayBuffer(8);
+    const error = new BigUint64Array(1);
     const returnValue = new ArrayBuffer(8);
 
     const success = g.function_info.invoke(
@@ -29,7 +29,7 @@ export function createMethod(info) {
     );
 
     if (!success) {
-      throw createGError(error);
+      throw createGError(error[0]);
     }
 
     const retVal = unboxArgument(returnType, returnValue);

--- a/src/types/callable/method.js
+++ b/src/types/callable/method.js
@@ -1,5 +1,6 @@
 import g from "../../bindings/mod.js";
 import { cast_ptr_u64 } from "../../base_utils/convert.ts";
+import { gerrorToString } from "../../utils/error.ts";
 import { getName } from "../../utils/string.ts";
 import { unboxArgument } from "../argument.js";
 import { parseCallableArgs } from "../callable.js";
@@ -29,7 +30,10 @@ export function createMethod(info) {
     );
 
     if (!success) {
-      console.error(`Error invoking method ${getName(info)}`);
+      console.error(
+        `Error invoking method ${getName(info)}:`,
+        gerrorToString(error),
+      );
       return;
     }
 

--- a/src/types/callable/method.js
+++ b/src/types/callable/method.js
@@ -15,7 +15,7 @@ export function createMethod(info) {
 
     inArgs.unshift(cast_ptr_u64(caller));
 
-    const error = new ArrayBuffer(16);
+    const error = new ArrayBuffer(8);
     const returnValue = new ArrayBuffer(8);
 
     const success = g.function_info.invoke(

--- a/src/types/callable/method.js
+++ b/src/types/callable/method.js
@@ -1,7 +1,6 @@
 import g from "../../bindings/mod.js";
 import { cast_ptr_u64 } from "../../base_utils/convert.ts";
-import { gerrorToString } from "../../utils/error.ts";
-import { getName } from "../../utils/string.ts";
+import { createGError } from "../../utils/error.ts";
 import { unboxArgument } from "../argument.js";
 import { parseCallableArgs } from "../callable.js";
 
@@ -30,11 +29,7 @@ export function createMethod(info) {
     );
 
     if (!success) {
-      console.error(
-        `Error invoking method ${getName(info)}:`,
-        gerrorToString(error),
-      );
-      return;
+      throw createGError(error);
     }
 
     const retVal = unboxArgument(returnType, returnValue);

--- a/src/types/callable/method.js
+++ b/src/types/callable/method.js
@@ -29,6 +29,10 @@ export function createMethod(info) {
     );
 
     if (!success) {
+      if (!error[0]) {
+        throw new Error(`Error invoking method ${getName(info)}`);
+      }
+
       throw createGError(error[0]);
     }
 

--- a/src/types/callable/vfunc.js
+++ b/src/types/callable/vfunc.js
@@ -1,5 +1,6 @@
 import g from "../../bindings/mod.js";
 import { cast_ptr_u64 } from "../../base_utils/convert.ts";
+import { gerrorToString } from "../../utils/error.ts";
 import { getName } from "../../utils/string.ts";
 import { unboxArgument } from "../argument.js";
 import { parseCallableArgs } from "../callable.js";
@@ -30,7 +31,10 @@ export function createVFunc(info) {
     );
 
     if (!success) {
-      console.error(`Error invoking vfunc ${getName(info)}`);
+      console.error(
+        `Error invoking method ${getName(info)}:`,
+        gerrorToString(error),
+      );
       return;
     }
 

--- a/src/types/callable/vfunc.js
+++ b/src/types/callable/vfunc.js
@@ -30,6 +30,10 @@ export function createVFunc(info) {
     );
 
     if (!success) {
+      if (!error[0]) {
+        throw new Error(`Error invoking vfunc ${getName(info)}`);
+      }
+
       throw createGError(error[0]);
     }
 

--- a/src/types/callable/vfunc.js
+++ b/src/types/callable/vfunc.js
@@ -1,7 +1,6 @@
 import g from "../../bindings/mod.js";
 import { cast_ptr_u64 } from "../../base_utils/convert.ts";
-import { gerrorToString } from "../../utils/error.ts";
-import { getName } from "../../utils/string.ts";
+import { createGError } from "../../utils/error.ts";
 import { unboxArgument } from "../argument.js";
 import { parseCallableArgs } from "../callable.js";
 
@@ -31,11 +30,7 @@ export function createVFunc(info) {
     );
 
     if (!success) {
-      console.error(
-        `Error invoking method ${getName(info)}:`,
-        gerrorToString(error),
-      );
-      return;
+      throw createGError(error);
     }
 
     const retVal = unboxArgument(returnType, returnValue);

--- a/src/types/callable/vfunc.js
+++ b/src/types/callable/vfunc.js
@@ -15,7 +15,7 @@ export function createVFunc(info) {
 
     inArgs.unshift(cast_ptr_u64(caller));
 
-    const error = new ArrayBuffer(16);
+    const error = new ArrayBuffer(8);
     const returnValue = new ArrayBuffer(8);
 
     const success = g.vfunc_info.invoke(

--- a/src/types/callable/vfunc.js
+++ b/src/types/callable/vfunc.js
@@ -15,7 +15,7 @@ export function createVFunc(info) {
 
     inArgs.unshift(cast_ptr_u64(caller));
 
-    const error = new ArrayBuffer(8);
+    const error = new BigUint64Array(1);
     const returnValue = new ArrayBuffer(8);
 
     const success = g.vfunc_info.invoke(
@@ -30,7 +30,7 @@ export function createVFunc(info) {
     );
 
     if (!success) {
-      throw createGError(error);
+      throw createGError(error[0]);
     }
 
     const retVal = unboxArgument(returnType, returnValue);

--- a/src/types/enum.js
+++ b/src/types/enum.js
@@ -1,16 +1,53 @@
 import g from "../bindings/mod.js";
 import handleInfo from "../handleInfo.js";
+import { getGLibError } from "../utils/error.ts";
+import { getName } from "../utils/string.ts";
 
-export function createEnum(info) {
-  const result = new Object();
-
+function defineValues(target, info) {
   const nValues = g.enum_info.get_n_values(info);
 
   for (let i = 0; i < nValues; i++) {
     const valueInfo = g.enum_info.get_value(info, i);
-    handleInfo(result, valueInfo);
+    handleInfo(target, valueInfo);
     g.base_info.unref(valueInfo);
   }
+}
+
+export function createError(info, error_domain) {
+  const GError = getGLibError();
+
+  const ObjectClass = class extends GError {
+    constructor(props) {
+      super({
+        ...props,
+        domain: g.quark_from_string(error_domain),
+      });
+    }
+
+    [Symbol.hasInstance](instance) {
+      return (instance instanceof GError) && (instance.domain === this.domain);
+    }
+  };
+
+  Object.defineProperty(ObjectClass, "name", {
+    value: getName(info),
+  });
+
+  defineValues(ObjectClass, info);
+
+  return ObjectClass;
+}
+
+export function createEnum(info) {
+  const error_domain = g.enum_info.get_error_domain(info);
+
+  if (error_domain) {
+    return createError(info, error_domain);
+  }
+
+  const result = new Object();
+
+  defineValues(result, info);
 
   return Object.freeze(result);
 }

--- a/src/types/struct.js
+++ b/src/types/struct.js
@@ -26,10 +26,10 @@ export function createStruct(info, gType) {
   const size = g.struct_info.get_size(info);
 
   const ObjectClass = class {
-    constructor() {
+    constructor(pointer) {
       Reflect.defineMetadata(
         "gi:ref",
-        cast_buf_ptr(new ArrayBuffer(size)),
+        pointer ?? cast_buf_ptr(new ArrayBuffer(size)),
         this,
       );
     }

--- a/src/types/struct.js
+++ b/src/types/struct.js
@@ -26,10 +26,10 @@ export function createStruct(info, gType) {
   const size = g.struct_info.get_size(info);
 
   const ObjectClass = class {
-    constructor(pointer) {
+    constructor() {
       Reflect.defineMetadata(
         "gi:ref",
-        pointer ?? cast_buf_ptr(new ArrayBuffer(size)),
+        cast_buf_ptr(new ArrayBuffer(size)),
         this,
       );
     }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,15 +1,11 @@
 import { cast_u64_ptr } from "../base_utils/convert.ts";
 import { require } from "../gi.js";
-import { ExtendedDataView } from "./dataview.js";
 
-export function createGError(errorBuffer: ArrayBuffer) {
+export function createGError(pointer: bigint) {
   const GError = getGLibError();
 
-  const dataView = new ExtendedDataView(errorBuffer);
-  const pointer = cast_u64_ptr(dataView.getBigUint64());
-
   const error = Object.create(GError.prototype);
-  Reflect.defineMetadata("gi:ref", pointer, error);
+  Reflect.defineMetadata("gi:ref", cast_u64_ptr(pointer), error);
 
   error.stack = new Error().stack;
 

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -10,6 +10,8 @@ export function createGError(errorBuffer: ArrayBuffer) {
 
   const error = new GError(pointer);
 
+  error.stack = new Error().stack;
+
   return error;
 }
 

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,25 +1,28 @@
 import { cast_u64_ptr } from "../base_utils/convert.ts";
-import g from "../bindings/mod.js";
-import { createStruct } from "../types/struct.js";
+import { require } from "../gi.js";
 import { ExtendedDataView } from "./dataview.js";
 
 export function createGError(errorBuffer: ArrayBuffer) {
+  const GError = getGLibError();
+
   const dataView = new ExtendedDataView(errorBuffer);
   const pointer = cast_u64_ptr(dataView.getBigUint64());
 
-  return new ErrorStruct(pointer);
+  const error = new GError(pointer);
+
+  return error;
 }
 
-function createErrorStruct() {
-  const errorInfo = g.irepository.find_by_name(null, "GLib", "Error");
-  const errorGtype = g.registered_type_info.get_g_type(errorInfo);
-
-  const ErrorStruct = createStruct(errorInfo, errorGtype);
-
-  return ErrorStruct;
+export function getGLibError() {
+  return require("GLib", "2.0").Error;
 }
 
-// make sure GLib is loaded
-g.irepository.require(null, "GLib", "2.0", 0, null);
+// function createErrorStruct(pointer: Deno.PointerValue) {
 
-const ErrorStruct = createErrorStruct();
+//   const ErrorStruct = createStruct(errorInfo, errorGtype);
+
+//   return new ErrorStruct(pointer);
+// }
+
+// // make sure GLib is loaded
+// g.irepository.require(null, "GLib", "2.0", 0, null);

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -8,7 +8,8 @@ export function createGError(errorBuffer: ArrayBuffer) {
   const dataView = new ExtendedDataView(errorBuffer);
   const pointer = cast_u64_ptr(dataView.getBigUint64());
 
-  const error = new GError(pointer);
+  const error = Object.create(GError.prototype);
+  Reflect.defineMetadata("gi:ref", pointer, error);
 
   error.stack = new Error().stack;
 

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -18,13 +18,3 @@ export function createGError(errorBuffer: ArrayBuffer) {
 export function getGLibError() {
   return require("GLib", "2.0").Error;
 }
-
-// function createErrorStruct(pointer: Deno.PointerValue) {
-
-//   const ErrorStruct = createStruct(errorInfo, errorGtype);
-
-//   return new ErrorStruct(pointer);
-// }
-
-// // make sure GLib is loaded
-// g.irepository.require(null, "GLib", "2.0", 0, null);

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,36 @@
+import { cast_u64_ptr } from "../base_utils/convert.ts";
+import g from "../bindings/mod.js";
+import { createStruct } from "../types/struct.js";
+import { ExtendedDataView } from "./dataview.js";
+
+export function gerrorToString(error: ArrayBuffer) {
+  const dataView = new ExtendedDataView(error);
+  const pointer = dataView.getBigUint64();
+
+  Reflect.defineMetadata("gi:ref", cast_u64_ptr(pointer), errorStruct);
+
+  const domain = errorStruct.domain;
+  const code = errorStruct.code;
+  const messageStr = errorStruct.message;
+
+  return `GLib.Error(${domain}, ${code}): ${messageStr}`;
+}
+
+g.irepository.require(null, "GLib", "2.0", 0, null);
+
+type ErrorStruct = {
+  domain: number;
+  code: number;
+  message: string;
+};
+
+function createErrorStruct() {
+  const errorInfo = g.irepository.find_by_name(null, "GLib", "Error");
+  const errorGtype = g.registered_type_info.get_g_type(errorInfo);
+
+  const ErrorStruct = createStruct(errorInfo, errorGtype);
+
+  return new ErrorStruct() as ErrorStruct;
+}
+
+const errorStruct = createErrorStruct();

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -3,26 +3,12 @@ import g from "../bindings/mod.js";
 import { createStruct } from "../types/struct.js";
 import { ExtendedDataView } from "./dataview.js";
 
-export function gerrorToString(error: ArrayBuffer) {
-  const dataView = new ExtendedDataView(error);
-  const pointer = dataView.getBigUint64();
+export function createGError(errorBuffer: ArrayBuffer) {
+  const dataView = new ExtendedDataView(errorBuffer);
+  const pointer = cast_u64_ptr(dataView.getBigUint64());
 
-  Reflect.defineMetadata("gi:ref", cast_u64_ptr(pointer), errorStruct);
-
-  const domain = errorStruct.domain;
-  const code = errorStruct.code;
-  const messageStr = errorStruct.message;
-
-  return `GLib.Error(${domain}, ${code}): ${messageStr}`;
+  return new ErrorStruct(pointer);
 }
-
-g.irepository.require(null, "GLib", "2.0", 0, null);
-
-type ErrorStruct = {
-  domain: number;
-  code: number;
-  message: string;
-};
 
 function createErrorStruct() {
   const errorInfo = g.irepository.find_by_name(null, "GLib", "Error");
@@ -30,7 +16,10 @@ function createErrorStruct() {
 
   const ErrorStruct = createStruct(errorInfo, errorGtype);
 
-  return new ErrorStruct() as ErrorStruct;
+  return ErrorStruct;
 }
 
-const errorStruct = createErrorStruct();
+// make sure GLib is loaded
+g.irepository.require(null, "GLib", "2.0", 0, null);
+
+const ErrorStruct = createErrorStruct();


### PR DESCRIPTION
By default, only the message `Error invoking method ${methodName}` is logged when invoking an error. This PR ~logs~ throws the GLib.Error correctly if an error happened while executing a function.

~I'm creating this as a draft PR because I think the better approach is to throw the `GLib.Error` (hence interrupting control flow), but I'm still thinking about creating a GLib.Error~ done