### PR TITLE
pass around outArgs as pointers

### DIFF
--- a/src/types/argument.js
+++ b/src/types/argument.js
@@ -11,10 +11,11 @@ import { ExtendedDataView } from "../utils/dataview.js";
 import { objectByGType } from "../utils/gobject.js";
 import { boxArray, unboxArray } from "./argument/array.js";
 import { boxInterface, unboxInterface } from "./argument/interface.js";
-import { getName } from "../utils/string.ts";
 
 export function initArgument(type) {
   const tag = g.type_info.get_tag(type);
+  const buffer = new ArrayBuffer(8);
+  const dataView = new ExtendedDataView(buffer);
 
   switch (tag) {
     case GITypeTag.INTERFACE: {
@@ -22,11 +23,14 @@ export function initArgument(type) {
       const g_type = g.registered_type_info.get_g_type(info);
       const o = objectByGType(g_type);
       const v = new o();
-      const result = cast_ptr_u64(Reflect.getOwnMetadata("gi:ref", v));
+      dataView.setBigUint64(
+        cast_ptr_u64(Reflect.getOwnMetadata("gi:ref", v)),
+      );
       g.base_info.unref(info);
-      return result;
     }
   }
+
+  return cast_ptr_u64(cast_buf_ptr(buffer));
 }
 
 /**

--- a/src/types/callable.js
+++ b/src/types/callable.js
@@ -1,3 +1,4 @@
+import { cast_u64_ptr, deref_buf } from "../base_utils/convert.ts";
 import {
   GIDirection,
   GIFunctionInfoFlags,
@@ -20,7 +21,15 @@ export function createArg(info) {
   const transfer = g.arg_info.get_ownership_transfer(info);
   const callerAllocates = g.arg_info.is_caller_allocates(info);
   const isReturn = g.arg_info.is_return_value(info);
-  return { type, arrLength, isSkip, direction, transfer, callerAllocates, isReturn };
+  return {
+    type,
+    arrLength,
+    isSkip,
+    direction,
+    transfer,
+    callerAllocates,
+    isReturn,
+  };
 }
 
 export function parseCallableArgs(info) {
@@ -38,7 +47,6 @@ export function parseCallableArgs(info) {
   const inArgsDetail = argDetails.filter(
     (arg) => !(arg.direction & GIDirection.OUT),
   );
-
 
   const outArgsDetail = argDetails.filter(
     (arg) => arg.direction & GIDirection.OUT,
@@ -69,7 +77,8 @@ export function parseCallableArgs(info) {
 
   const parseOutArgs = (outArgs) => {
     return outArgsDetail.map((d, i) => {
-      return unboxArgument(d.type, new BigUint64Array([outArgs[i]]).buffer);
+      const buffer = deref_buf(cast_u64_ptr(outArgs[i]), 8);
+      return unboxArgument(d.type, buffer);
     });
   };
 


### PR DESCRIPTION
This method works by setting the outArgs initially by creating pointers. Setting the pointer for Interface types seems to be unnecessary, because they are just going to be reset (as they are out parameters.)

however, this can be useful for inOut parameters, so I'm keeping the code for now.

Please advise on this method, thanks!!