### PR TITLE
Unbox the descendant objects while unboxing arguments

### DIFF
--- a/examples/builder.ts
+++ b/examples/builder.ts
@@ -12,10 +12,8 @@ function activate(app: Gtk.Application) {
   const root = builder.getObject("root") as Gtk.Widget;
 
   const actionButton = builder.getObject("actionButton") as Gtk.Button;
-  Object.setPrototypeOf(actionButton, Gtk.Button.prototype);
   actionButton.on("clicked", () => console.log("Action!"));
   const closeButton = builder.getObject("closeButton") as Gtk.Button;
-  Object.setPrototypeOf(closeButton, Gtk.Button.prototype);
   closeButton.on("clicked", () => win.close());
 
   const win = Gtk.ApplicationWindow.new(app);

--- a/examples/builder.ts
+++ b/examples/builder.ts
@@ -1,5 +1,4 @@
-import { require } from "../mod.ts";
-const Gtk = require("Gtk", "4.0");
+import Gtk from "https://gir.deno.dev/Gtk-4.0";
 
 const app = Gtk.Application.new("com.deno_gi.builder", 0);
 

--- a/examples/builder.ts
+++ b/examples/builder.ts
@@ -1,4 +1,5 @@
-import Gtk from "https://gir.deno.dev/Gtk-4.0";
+import { require } from "../mod.ts";
+const Gtk = require("Gtk", "4.0");
 
 const app = Gtk.Application.new("com.deno_gi.builder", 0);
 

--- a/src/bindings/gobject.js
+++ b/src/bindings/gobject.js
@@ -38,8 +38,6 @@ const { g } = openLib(libName("gobject-2.0", 0), {
     type: {
       default_interface_ref: $pointer($i64),
       parent: $i64($i64),
-      name_from_instance: $string($pointer),
-      from_name: $i64($string),
       is_a: $bool($i64, $i64),
     },
     type_class: {

--- a/src/bindings/gobject.js
+++ b/src/bindings/gobject.js
@@ -38,6 +38,8 @@ const { g } = openLib(libName("gobject-2.0", 0), {
     type: {
       default_interface_ref: $pointer($i64),
       parent: $i64($i64),
+      name_from_instance: $string($pointer),
+      from_name: $i64($string),
     },
     type_class: {
       ref: $pointer($i64),

--- a/src/bindings/gobject.js
+++ b/src/bindings/gobject.js
@@ -40,6 +40,7 @@ const { g } = openLib(libName("gobject-2.0", 0), {
       parent: $i64($i64),
       name_from_instance: $string($pointer),
       from_name: $i64($string),
+      is_a: $bool($i64, $i64),
     },
     type_class: {
       ref: $pointer($i64),

--- a/src/types/argument/interface.js
+++ b/src/types/argument/interface.js
@@ -2,7 +2,7 @@ import { cast_ptr_u64, cast_u64_ptr } from "../../base_utils/convert.ts";
 import { GIInfoType, GType } from "../../bindings/enums.js";
 import g from "../../bindings/mod.js";
 import { ExtendedDataView } from "../../utils/dataview.js";
-import { objectByGType } from "../../utils/gobject.js";
+import { objectByGType, objectByInfo } from "../../utils/gobject.js";
 import { createCallback } from "../callback.js";
 
 export function boxInterface(info, value) {
@@ -66,7 +66,12 @@ export function unboxInterface(
         }
       }
 
-      const result = Object.create(objectByGType(leaf_gType).prototype);
+      // only use gType if the object is a descendant of GObject.Object
+      const object = (leaf_gType === gType || leaf_gType === GType.NONE)
+        ? objectByInfo(info)
+        : objectByGType(leaf_gType);
+
+      const result = Object.create(object.prototype);
 
       Reflect.defineMetadata(
         "gi:ref",

--- a/src/types/argument/interface.js
+++ b/src/types/argument/interface.js
@@ -1,8 +1,12 @@
-import { cast_ptr_u64, cast_u64_ptr } from "../../base_utils/convert.ts";
+import {
+  cast_ptr_u64,
+  cast_u64_ptr,
+  deref_buf,
+} from "../../base_utils/convert.ts";
 import { GIInfoType, GType } from "../../bindings/enums.js";
 import g from "../../bindings/mod.js";
 import { ExtendedDataView } from "../../utils/dataview.js";
-import { objectByGType, objectByInfo } from "../../utils/gobject.js";
+import { objectByGType } from "../../utils/gobject.js";
 import { createCallback } from "../callback.js";
 
 export function boxInterface(info, value) {
@@ -32,46 +36,23 @@ export function unboxInterface(
 ) {
   const dataView = new ExtendedDataView(argValue);
   const type = g.base_info.get_type(info);
-  const gType = g.registered_type_info.get_g_type(info);
-  /*
-  let value = dataView.getBigUint64();
+  let gType = g.registered_type_info.get_g_type(info);
 
-  if (gType == GObject.g_value_get_type()) {
-    const buffer = new BigUint64Array(
-      Deno.UnsafePointerView.getArrayBuffer(value, 24)
-    );
-
-    gType = buffer.at(0);
-    value = BigInt(unboxGValue(buffer, gType));
-    dataView.buffer = new BigUint64Array([value]).buffer;
+  if (g.type.is_a(gType, GType.OBJECT)) {
+    const pointer = dataView.getBigUint64();
+    const typeInstance = new ExtendedDataView(
+      deref_buf(cast_u64_ptr(pointer), 8),
+    )
+      .getBigUint64();
+    gType = new ExtendedDataView(deref_buf(cast_u64_ptr(typeInstance), 8))
+      .getBigUint64();
   }
-  */
 
   switch (type) {
     case GIInfoType.OBJECT:
     case GIInfoType.STRUCT:
     case GIInfoType.INTERFACE: {
-      // This is needed otherwise we assign to a read-only property
-      let leaf_gType = gType;
-
-      // get the descendant gType for GObject.Object
-      if (g.type.is_a(gType, GType.OBJECT)) {
-        // TODO: find a way to get the gtype from the object
-        // TYPE_FROM_INSTANCE seems to be a macro, so we can't call it
-        const type_name = g.type.name_from_instance(cast_u64_ptr(pointer));
-        const descendant_gType = type_name ? g.type.from_name(type_name) : null;
-
-        if (descendant_gType) {
-          leaf_gType = descendant_gType;
-        }
-      }
-
-      // only use gType if the object is a descendant of GObject.Object
-      const object = (leaf_gType === gType || leaf_gType === GType.NONE)
-        ? objectByInfo(info)
-        : objectByGType(leaf_gType);
-
-      const result = Object.create(object.prototype);
+      const result = Object.create(objectByGType(gType).prototype);
 
       Reflect.defineMetadata(
         "gi:ref",

--- a/src/types/argument/interface.js
+++ b/src/types/argument/interface.js
@@ -53,7 +53,6 @@ export function unboxInterface(
     case GIInfoType.STRUCT:
     case GIInfoType.INTERFACE: {
       const result = Object.create(objectByGType(gType).prototype);
-
       Reflect.defineMetadata(
         "gi:ref",
         cast_u64_ptr(dataView.getBigUint64()),

--- a/src/types/argument/interface.js
+++ b/src/types/argument/interface.js
@@ -55,7 +55,7 @@ export function unboxInterface(
       let leaf_gType = gType;
 
       // get the descendant gType for GObject.Object
-      if (gType === BigInt(GType.OBJECT)) {
+      if (g.type.is_a(gType, GType.OBJECT)) {
         // TODO: find a way to get the gtype from the object
         // TYPE_FROM_INSTANCE seems to be a macro, so we can't call it
         const type_name = g.type.name_from_instance(cast_u64_ptr(pointer));


### PR DESCRIPTION
This PR allows for GObject.Object values to be automatically recognised and unboxed as their descendant types.

For example, a `builder.getObject` returns a `GObject` as per the introspection data, but in reality, usually the returned data is a `Gtk.Widget`. Here we get the gType of the object and then instantiate it as a `Gtk.Widget` instead of just a `GObject`.

Thanks!

I'm still looking for a way to do this directly without first getting a string and then a gtype. Suggestions welcome!!