### PR TITLE
Vfuncs

### DIFF
--- a/src/bindings/girepository.js
+++ b/src/bindings/girepository.js
@@ -112,6 +112,7 @@ const { g } = openLib(libName("girepository-1.0", 1), {
       get_type: $pointer($pointer),
       get_field: $i32($pointer,$pointer, $buffer),
       set_field: $i32($pointer,$pointer, $buffer),
+      get_offset: $i32($pointer),
     },
   },
 });

--- a/src/bindings/girepository.js
+++ b/src/bindings/girepository.js
@@ -101,6 +101,7 @@ const { g } = openLib(libName("girepository-1.0", 1), {
       get_vfunc: $pointer($pointer, $i32),
       get_n_properties: $i32($pointer),
       get_property: $pointer($pointer, $i32),
+      get_iface_struct: $pointer($pointer),
     },
     property_info: {
       get_flags: $i32($pointer),

--- a/src/bindings/girepository.js
+++ b/src/bindings/girepository.js
@@ -28,6 +28,7 @@ const { g } = openLib(libName("girepository-1.0", 1), {
     },
     base_info: {
       get_name: $string($pointer),
+      get_container: $pointer($pointer),
       is_deprecated: $bool($pointer),
       get_type: $i32($pointer),
       ref: $void($pointer),
@@ -75,6 +76,7 @@ const { g } = openLib(libName("girepository-1.0", 1), {
       get_n_fields: $i32($pointer),
       get_field: $pointer($pointer, $i32),
       get_size: $i32($pointer),
+      find_field: $pointer($pointer, $string),
     },
     object_info: {
       get_n_methods: $i32($pointer),
@@ -110,7 +112,7 @@ const { g } = openLib(libName("girepository-1.0", 1), {
     field_info: {
       get_flags: $i32($pointer),
       get_type: $pointer($pointer),
-      get_field: $i32($pointer,$pointer, $buffer),
+      get_field: $bool($pointer,$pointer, $buffer),
       set_field: $i32($pointer,$pointer, $buffer),
       get_offset: $i32($pointer),
     },

--- a/src/types/callable.js
+++ b/src/types/callable.js
@@ -125,7 +125,7 @@ export function handleCallable(target, info) {
       }
 
       const value = createVFunc(info);
-      Object.defineProperty(target.prototype, name, {
+      Object.defineProperty(target.prototype, `vfunc_` + name, {
         enumerable: true,
         value(...args) {
           return value(


### PR DESCRIPTION
This PR allows the setting of `vfunc` functions. These are "virtual functions" that will usually be called as the default callback for example, a signal or a method. By allowing setting, we effectively allow subclassing them.

This pattern can be used, for example, to allow adding a default handler for a `GtkApplication` using the following pattern:

```js
class App extends Gtk.Application {
  // code...
}

const app = new App();

app.vfunc_activate = () => {
  console.log("activated...");
  this.show_main_window();
}
```

You can see that this is similar to adding a `connect` handler. This is like setting a function. For example, when we set the `activate` vfunc, it's as if we're setting the function that executes when the function is executed.

There is also a pattern typical in GJS that allows overriding vfuncs directly, but I still need to implement that.

```js
class App extends Gtk.Application {
  // code...
  vfunc_activate() {
    // create and show the main window
    this.show_main_window();
  }
};
```

This PR will also help implement `GtkBuilderScope`'s `vfunc_create_closure`, which is used to make sure callbacks from GtkBuilder template files (XML) are correctly attached to the JS-side callbacks. I will include the code in a future PR (probably #20)

I also need to log a warning or error if a vfunc cannot be set.