### PR TITLE
fix getting child type not working

### DIFF
--- a/src/types/argument/interface.js
+++ b/src/types/argument/interface.js
@@ -45,10 +45,9 @@ export function unboxInterface(
     const pointer = dataView.getBigUint64();
     const typeInstance = new ExtendedDataView(
       deref_buf(cast_u64_ptr(pointer), 8),
-    )
-      .getBigUint64();
-    gType = new ExtendedDataView(deref_buf(cast_u64_ptr(typeInstance), 8))
-      .getBigUint64();
+    );
+
+    gType = typeInstance.getBigUint64();
   }
 
   switch (type) {


### PR DESCRIPTION
This issue is a follow-up to #19 and addresses a regression caused by #17 because before, we got the pointer of a pointer (twice) and now we just need to get the pointer once.

As a side note, we need integration tests.

The priority for this PR is urgent.