### PR TITLE
get the closest registered parent gType for unregisted gTypes

### DIFF
--- a/src/utils/gobject.js
+++ b/src/utils/gobject.js
@@ -1,4 +1,4 @@
-import { GIInfoType } from "../bindings/enums.js";
+import { GIInfoType, GType } from "../bindings/enums.js";
 import g from "../bindings/mod.js";
 import { createEnum } from "../types/enum.js";
 import { createInterface } from "../types/interface.js";
@@ -7,7 +7,24 @@ import { createStruct } from "../types/struct.js";
 
 export const cache = new Map();
 
-export function objectByGType(gType) {
+// find the closest registed parent type. sometimes gTypes may not be visible
+// in gobject-introspection for one of two reasons: 1. they were registered
+// as by the user as a static type or 2. the namespace they are in is not
+// loaded.
+function getBaseGType(gType) {
+  if (!g.type.is_a(gType, GType.OBJECT)) return null;
+
+  let baseGType = gType;
+  while (!g.irepository.find_by_gtype(null, baseGType)) {
+    baseGType = g.type.parent(baseGType);
+  }
+
+  return baseGType;
+}
+
+export function objectByGType(_gType) {
+  const gType = getBaseGType(_gType);
+
   if (cache.has(gType)) {
     return cache.get(gType);
   }

--- a/src/utils/gobject.js
+++ b/src/utils/gobject.js
@@ -30,6 +30,13 @@ export function objectByGType(_gType) {
   }
 
   const info = g.irepository.find_by_gtype(null, gType);
+
+  if (!info) {
+    throw new Error(
+      `Could not find GObjectInfo for ${_gType}. Is it a valid registered type?`,
+    );
+  }
+
   const result = createGObject(info, gType);
   Object.freeze(result);
   cache.set(gType, result);


### PR DESCRIPTION
Using `deno_gi`, I sometimes stumbled into issues with random segmentation faults. And it turns out, some of them are caused because the library can't find the given `GIBaseInfo` for a specific `gType`. This was partially solved with #6, but some issues remain.

It's essential to try and figure out why this issue arises anyway, i.e. why some `gTypes` are not "registered" (read "known by gobject-introspection"). It turns out there are 2 reasons I discovered (there could potentially be more):

### 1. The types were registered by the user

The above issue can happen when the user registers a new class in the [GObject type system](https://docs.gtk.org/gobject/concepts.html). The resulting class is known by `GObject`, but not by `gi`. This is because `gi` (gobject-introspection) can only know types from `.typelib` files.

Now this issue is very rare, as no current code in `deno_gi` registers new objects, but the issue will become more prevalent in #20, as that PR adds support for registering classes in a nice format. As such, we don't need to care for this now.

### 2. Unloaded namespaces

It is also very possible to get an object from a separate namespace that has not been loaded by `gi`. I will provide an example:

`Gdk.Display.getDefault()` returns an object of type `Gdk.Display`. However, on linux, that object will either be [`GdkWayland.WaylandDisplay`](https://docs.gtk.org/gdk4-wayland/class.WaylandDisplay.html) or [`GdkX11.X11Display`](https://docs.gtk.org/gdk4-x11/class.X11Display.html). Now the `Gdk.Display.getDefault()` method will return an object of gtype which either points to a `X11Display` or `WaylandDisplay`, but `gi` does not know these types, because `Gdk` doesn't depend on either `GdkX11` or `GdkWayland`, causing deno_gi to crash because the above libraries are not loaded (even though their `.typelib`s are installed, gi will not automatically load them.) This example actually exposes the above bug: https://github.com/ahgilak/deno_gi/blob/main/examples/stylesheet.ts.

## Conclusion

While we now know what causes these issues, we can fix them. For the first one, the solution is out-of-scope and requires keeping track of all the user-registered types.

For the issue, it would be best if we could automatically register new needed namespaces with gi, but that is not possible currently. The only way around this issue is to work up the parent chain and choose the closest parent that is known to gi.

For example:

`GdkWayland.WaylandDisplay` -> `Gdk.Display` -> `GObject.Object`.

Because gi doesn't know about `GdkWayland` (unless we manually `require` it), we get the parent of the type, and find it to be `Gdk.Display`. Because gi knows about this type, we can construct an object of that type (even though we won't be able to access `GdkWayland.WaylandDisplay` methods) instead of crashing.

In the very unlikely case that no object type is recognised by gi, we throw an error, and the user needs to act accordingly. This behavior is similar to GJS.