### PR TITLE
use `peek_ptr` consistently.

### DIFF
--- a/src/gi.js
+++ b/src/gi.js
@@ -1,7 +1,6 @@
-import { cast_u64_ptr, deref_buf, deref_str } from "./base_utils/convert.ts";
+import { cast_u64_ptr, deref_str } from "./base_utils/convert.ts";
 import g from "./bindings/mod.js";
 import handleInfo from "./handleInfo.js";
-import { ExtendedDataView } from "./utils/dataview.js";
 import { hasOverride, loadOverride } from "./overrides/mod.ts";
 import { peek_ptr } from "./base_utils/convert.ts";
 
@@ -80,10 +79,7 @@ function load(namespace, version) {
     let message = "Unknown error";
 
     if (error) {
-      const dataView = new ExtendedDataView(
-        deref_buf(cast_u64_ptr(error[0]), 16),
-      );
-      message = deref_str(cast_u64_ptr(dataView.getBigUint64(8)));
+      message = deref_str(peek_ptr(cast_u64_ptr(error[0]), 8));
     }
 
     const versionString = version ? ` version ${version}` : "";

--- a/src/gi.js
+++ b/src/gi.js
@@ -21,8 +21,7 @@ function getLatestVersion(namespace) {
 
   for (let i = 0; i < g.slist.length(versions); i++) {
     const version = g.slist.nth(versions, i);
-    const dataView = new ExtendedDataView(deref_buf(version, 8));
-    const pointer = cast_u64_ptr(dataView.getBigUint64());
+    const pointer = peek_ptr(version);
 
     array.push(deref_str(pointer));
   }

--- a/src/types/argument/interface.js
+++ b/src/types/argument/interface.js
@@ -1,3 +1,4 @@
+import { peek_ptr } from "../../base_utils/convert.ts";
 import {
   cast_ptr_u64,
   cast_u64_ptr,
@@ -42,12 +43,9 @@ export function unboxInterface(
   let gType = g.registered_type_info.get_g_type(info);
 
   if (g.type.is_a(gType, GType.OBJECT)) {
-    const pointer = dataView.getBigUint64();
-    const typeInstance = new ExtendedDataView(
-      deref_buf(cast_u64_ptr(pointer), 8),
-    );
+    const typeInstance = peek_ptr(cast_u64_ptr(dataView.getBigUint64()));
 
-    gType = typeInstance.getBigUint64();
+    gType = cast_ptr_u64(typeInstance);
   }
 
   switch (type) {


### PR DESCRIPTION
`peek_ptr` is a small nice utility introduced in a previous PR.

This PR enforces the use of the utility across all similar usage patterns where we need to get the pointer pointed to by another pointer (😅).