### PR TITLE
Use ArrayBuffers for passing values

### DIFF
--- a/src/base_utils/convert.ts
+++ b/src/base_utils/convert.ts
@@ -52,3 +52,7 @@ export function peek_ptr(pointer: Deno.PointerObject, offset = 0) {
   return cast_u64_ptr(new ExtendedDataView(deref_buf(pointer, 8, offset))
     .getBigUint64());
 }
+
+export function deref_ptr(value: ArrayBufferLike) {
+  return cast_u64_ptr(new ExtendedDataView(value).getBigUint64());
+}

--- a/src/types/argument.js
+++ b/src/types/argument.js
@@ -59,7 +59,7 @@ export function unboxArgument(type, buffer, offset) {
       return null;
 
     case GITypeTag.UNICHAR:
-      return String.fromCharCode(dataView.getUint8());
+      return String.fromCharCode(dataView.getUint32());
 
     case GITypeTag.BOOLEAN:
       return Boolean(dataView.getUint8());
@@ -92,8 +92,10 @@ export function unboxArgument(type, buffer, offset) {
       return dataView.getBigInt64();
 
     case GITypeTag.DOUBLE:
-    case GITypeTag.GTYPE:
       return dataView.getFloat64();
+
+    case GITypeTag.GTYPE:
+      return dataView.getBigUint64();
 
     case GITypeTag.UTF8:
     case GITypeTag.FILENAME: {
@@ -136,6 +138,10 @@ export function boxArgument(type, value) {
 
     case GITypeTag.UINT8:
       dataView.setUint8(value);
+      break;
+
+    case GITypeTag.UNICHAR:
+      dataView.setUint32(String(value).codePointAt(0));
       break;
 
     case GITypeTag.INT8:

--- a/src/types/argument.js
+++ b/src/types/argument.js
@@ -17,6 +17,7 @@ export function initArgument(type) {
 
   switch (tag) {
     case GITypeTag.INTERFACE: {
+      // TODO: just generate a space large enough to hold the type
       const info = g.type_info.get_interface(type);
       const o = objectByInfo(info);
       const v = new o();
@@ -25,7 +26,8 @@ export function initArgument(type) {
       return result;
     }
     default:
-      return 0n;
+      // generate a new pointer
+      return cast_ptr_u64(cast_buf_ptr(new ArrayBuffer(8)));
   }
 }
 

--- a/src/types/argument.js
+++ b/src/types/argument.js
@@ -145,11 +145,11 @@ export function boxArgument(type, value) {
       break;
 
     case GITypeTag.FLOAT:
-      dataView.setFloat32(0, value);
+      dataView.setFloat32(value);
       break;
 
     case GITypeTag.DOUBLE:
-      dataView.setFloat64(0, value);
+      dataView.setFloat64(value);
       break;
 
     case GITypeTag.UTF8:

--- a/src/types/argument.js
+++ b/src/types/argument.js
@@ -26,18 +26,6 @@ export function initArgument(type) {
       g.base_info.unref(info);
       return result;
     }
-    // case GITypeTag.BOOLEAN:
-    // case GITypeTag.UINT8:
-    // case GITypeTag.INT8:
-    // case GITypeTag.UINT16:
-    // case GITypeTag.INT16:
-    // case GITypeTag.UINT32:
-    // case GITypeTag.INT32:
-    // case GITypeTag.FLOAT:
-    // case GITypeTag.UINT64:
-    // case GITypeTag.INT64:
-    // case GITypeTag.DOUBLE:
-    //   return 0n;
     default:
       // generate a new pointer
       return cast_ptr_u64(cast_buf_ptr(new ArrayBuffer(8)));

--- a/src/types/argument.js
+++ b/src/types/argument.js
@@ -153,11 +153,15 @@ export function boxArgument(type, value) {
       break;
 
     case GITypeTag.UINT64:
-      dataView.setBigUint64(value);
+      dataView.setBigUint64(
+        typeof value === "bigint" ? value : Math.trunc(value),
+      );
       break;
 
     case GITypeTag.INT64:
-      dataView.setBigInt64(value);
+      dataView.setBigInt64(
+        typeof value === "bigint" ? value : Math.trunc(value),
+      );
       break;
 
     case GITypeTag.FLOAT:

--- a/src/types/argument/interface.js
+++ b/src/types/argument/interface.js
@@ -3,6 +3,7 @@ import {
   cast_ptr_u64,
   cast_u64_ptr,
   deref_buf,
+  deref_ptr,
 } from "../../base_utils/convert.ts";
 import { GIInfoType, GType } from "../../bindings/enums.js";
 import g from "../../bindings/mod.js";
@@ -33,10 +34,9 @@ export function boxInterface(info, value) {
   }
 }
 
-export function unboxInterface(
-  info,
-  pointer,
-) {
+export function unboxInterface(info, buffer) {
+  const pointer = deref_ptr(buffer);
+
   const argValue = deref_buf(pointer, 8);
   const dataView = new ExtendedDataView(argValue);
   const type = g.base_info.get_type(info);

--- a/src/types/argument/list.js
+++ b/src/types/argument/list.js
@@ -1,20 +1,22 @@
-import { deref_buf } from "../../base_utils/convert.ts";
 import g from "../../bindings/girepository.js";
 import { unboxArgument } from "../argument.js";
+import { ExtendedDataView } from "../../utils/dataview.js";
 
 /**
  * @param {Deno.PointerValue} info
- * @param {BigInt} pointer
+ * @param {ArrayBuffer} buffer
  * @returns
  */
-export function unboxList(info, pointer) {
+export function unboxList(info, buffer) {
   const paramType = g.type_info.get_param_type(info, 0);
   const result = [];
 
-  while (pointer) {
-    const [value, next] = new BigUint64Array(deref_buf(pointer, 16));
-    result.push(unboxArgument(paramType, value));
-    pointer = Deno.UnsafePointer.create(next);
+  const dataView = new ExtendedDataView(buffer);
+  let i = 0;
+
+  while (dataView.getUint8()) {
+    result.push(unboxArgument(paramType, buffer, i * 8));
+    i++;
   }
 
   g.base_info.unref(paramType);

--- a/src/types/callable.js
+++ b/src/types/callable.js
@@ -73,8 +73,8 @@ export function parseCallableArgs(info) {
   const initOutArgs = () => {
     const buffer = new ArrayBuffer(8 * outArgsDetail.length);
     const dataView = new ExtendedDataView(buffer);
-    outArgsDetail.forEach((detail) => {
-      dataView.setBigUint64(initArgument(detail.type));
+    outArgsDetail.forEach((detail, index) => {
+      dataView.setBigUint64(initArgument(detail.type), index * 8);
     });
 
     return buffer;

--- a/src/types/callable.js
+++ b/src/types/callable.js
@@ -71,12 +71,18 @@ export function parseCallableArgs(info) {
   };
 
   const initOutArgs = () => {
-    return new BigUint64Array(outArgsDetail.map((d) => initArgument(d.type)));
+    const buffer = new ArrayBuffer(8 * outArgsDetail.length);
+    const dataView = new ExtendedDataView(buffer);
+    outArgsDetail.forEach((detail) => {
+      dataView.setBigUint64(initArgument(detail.type));
+    });
+
+    return buffer;
   };
 
   const parseOutArgs = (outArgs) => {
     return outArgsDetail.map((d, i) => {
-      return unboxArgument(d.type, outArgs[i]);
+      return unboxArgument(d.type, outArgs, i * 8);
     });
   };
 

--- a/src/types/callable/function.js
+++ b/src/types/callable/function.js
@@ -13,14 +13,14 @@ export function createFunction(info) {
     const outArgs = initOutArgs();
 
     const error = new BigUint64Array(1);
-    const returnValue = new BigUint64Array(1);
+    const returnValue = new ArrayBuffer(8);
 
     const success = g.function_info.invoke(
       info,
       new BigUint64Array(inArgs),
       inArgs.length,
       outArgs,
-      outArgs.length,
+      outArgs.byteLength / 8,
       returnValue,
       error,
     );
@@ -33,11 +33,10 @@ export function createFunction(info) {
       throw createGError(error[0]);
     }
 
-    const retVal = unboxArgument(returnType, returnValue[0]);
+    const retVal = unboxArgument(returnType, returnValue);
 
-    if (outArgs.length > 0) {
+    if (outArgs.byteLength > 0) {
       const parsedOutArgs = parseOutArgs(outArgs);
-
       // don't include a return value if it's void
       if (g.type_info.get_tag(returnType) !== GITypeTag.VOID) {
         return [retVal, ...parsedOutArgs];

--- a/src/types/callable/method.js
+++ b/src/types/callable/method.js
@@ -16,14 +16,14 @@ export function createMethod(info) {
     inArgs.unshift(cast_ptr_u64(caller));
 
     const error = new BigUint64Array(1);
-    const returnValue = new BigUint64Array(1);
+    const returnValue = new ArrayBuffer(8);
 
     const success = g.function_info.invoke(
       info,
       new BigUint64Array(inArgs),
       inArgs.length,
       outArgs,
-      outArgs.length,
+      outArgs.byteLength / 8,
       returnValue,
       error,
     );
@@ -36,9 +36,9 @@ export function createMethod(info) {
       throw createGError(error[0]);
     }
 
-    const retVal = unboxArgument(returnType, returnValue[0]);
+    const retVal = unboxArgument(returnType, returnValue);
 
-    if (outArgs.length > 0) {
+    if (outArgs.byteLength > 0) {
       return [retVal, ...parseOutArgs(outArgs)];
     }
 

--- a/src/types/callable/vfunc.js
+++ b/src/types/callable/vfunc.js
@@ -16,7 +16,7 @@ export function createVFunc(info) {
     inArgs.unshift(cast_ptr_u64(caller));
 
     const error = new BigUint64Array(1);
-    const returnValue = new BigUint64Array(1);
+    const returnValue = new ArrayBuffer(8);
 
     const success = g.vfunc_info.invoke(
       info,
@@ -24,7 +24,7 @@ export function createVFunc(info) {
       new BigUint64Array(inArgs),
       inArgs.length,
       outArgs,
-      outArgs.length,
+      outArgs.byteLength / 8,
       returnValue,
       error,
     );
@@ -37,9 +37,9 @@ export function createVFunc(info) {
       throw createGError(error[0]);
     }
 
-    const retVal = unboxArgument(returnType, returnValue[0]);
+    const retVal = unboxArgument(returnType, returnValue);
 
-    if (outArgs.length > 0) {
+    if (outArgs.byteLength > 0) {
       return [retVal, ...parseOutArgs(outArgs)];
     }
 

--- a/src/types/callback.js
+++ b/src/types/callback.js
@@ -1,8 +1,8 @@
 import g from "../bindings/mod.js";
 import { GITypeTag } from "../bindings/enums.js";
 import { boxArgument, unboxArgument } from "./argument.js";
-import { cast_ptr_u64 } from "../base_utils/convert.ts";
 import { createArg } from "./callable.js";
+import { deref_buf } from "../base_utils/convert.ts";
 
 const nativeTypes = {
   [GITypeTag.BOOLEAN]: "i32",
@@ -34,7 +34,7 @@ function parseArgs(
 
     const result = nativeTypes[tag]
       ? value
-      : unboxArgument(argType, cast_ptr_u64(value));
+      : unboxArgument(argType, deref_buf(value, 8));
 
     g.base_info.unref(argInfo);
     g.base_info.unref(argType);

--- a/src/types/constant.js
+++ b/src/types/constant.js
@@ -2,7 +2,7 @@ import g from "../bindings/mod.js";
 import { unboxArgument } from "./argument.js";
 
 export function createConstant(info) {
-  const giValue = new BigUint64Array(1);
+  const giValue = new ArrayBuffer(8);
   const giType = g.constant_info.get_type(info);
   const size = g.constant_info.get_value(info, giValue);
 
@@ -10,7 +10,7 @@ export function createConstant(info) {
     return null;
   }
 
-  const result = unboxArgument(giType, giValue[0]);
+  const result = unboxArgument(giType, giValue);
   g.base_info.unref(giType);
 
   return result;

--- a/src/types/field.js
+++ b/src/types/field.js
@@ -27,7 +27,7 @@ export function handleField(
         throw new Error(`Field ${name} is not readable`);
       }
 
-      const argument = new BigUint64Array(1);
+      const argument = new ArrayBuffer(8);
 
       g.field_info.get_field(
         fieldInfo,
@@ -35,10 +35,7 @@ export function handleField(
         argument,
       );
 
-      const value = unboxArgument(
-        type,
-        argument[0],
-      );
+      const value = unboxArgument(type, argument);
 
       return value;
     },

--- a/src/types/prop.js
+++ b/src/types/prop.js
@@ -1,4 +1,4 @@
-import { deref_buf, ref_buf } from "../base_utils/convert.ts";
+import { deref_buf } from "../base_utils/convert.ts";
 import { GParamFlags } from "../bindings/enums.js";
 import g from "../bindings/mod.js";
 import { ExtendedDataView } from "../utils/dataview.js";
@@ -41,10 +41,7 @@ export function handleProp(
       );
 
       const argValue = unboxValue(boxedValue, boxedType);
-      const value = unboxArgument(
-        argType,
-        ref_buf(argValue)[0],
-      );
+      const value = unboxArgument(argType, deref_buf(argValue, 8));
 
       return value;
     },

--- a/src/utils/dataview.js
+++ b/src/utils/dataview.js
@@ -51,11 +51,11 @@ export class ExtendedDataView {
   }
 
   setUint8(value, offset = 0) {
-    return this.#dataView.setUint8(value, offset);
+    return this.#dataView.setUint8(offset, value);
   }
 
   setInt8(value, offset = 0) {
-    return this.#dataView.setInt8(value, offset);
+    return this.#dataView.setInt8(offset, value);
   }
 
   setUint16(value, offset = 0) {


### PR DESCRIPTION
Hello. This PR yet again reverts to using `ArrayBuffers` for passing values. This is in contrast to using `BigUint64Arrays` as it's quite hard to use signed numbers with them.

I aim to further use `ArrayBuffers` everywhere, like in `initArgument`, `inArgs`, etc...

These issues were surfaced by work I'm doing in regards to #14. When this PR is merged, I'll be able to update the tests PR to finally add tests from `libeverything`, then we will add marshalling tests.