### PR TITLE
Handle GLib.Errors better

### DIFF
--- a/src/bindings/girepository.js
+++ b/src/bindings/girepository.js
@@ -18,6 +18,7 @@ const { g } = openLib(libName("girepository-1.0", 1), {
       get_n_infos: $i32($pointer, $string),
       get_info: $pointer($pointer, $string, $i32),
       find_by_gtype: $pointer($pointer, $i64),
+      find_by_name: $pointer($pointer, $string, $string),
       enumerate_versions: $pointer($pointer, $string),
       get_version: $string($pointer, $string),
       is_registered: $bool($pointer, $string, $string),
@@ -28,6 +29,7 @@ const { g } = openLib(libName("girepository-1.0", 1), {
     },
     base_info: {
       get_name: $string($pointer),
+      get_namespace: $string($pointer),
       get_container: $pointer($pointer),
       is_deprecated: $bool($pointer),
       get_type: $i32($pointer),

--- a/src/handleInfo.js
+++ b/src/handleInfo.js
@@ -2,6 +2,7 @@ import { GIInfoType } from "./bindings/enums.js";
 import g from "./bindings/mod.js";
 import { handleCallable } from "./types/callable.js";
 import { createConstant } from "./types/constant.js";
+import { createEnum } from "./types/enum.js";
 import { handleSignal } from "./types/signal.js";
 import { objectByInfo } from "./utils/gobject.js";
 import { getName } from "./utils/string.ts";
@@ -12,6 +13,12 @@ export function handleInfo(target, info) {
 
   switch (type) {
     case GIInfoType.ENUM:
+      // create enums directly so that we can lookup GLib.Errors later
+      g.base_info.ref(info);
+      Object.defineProperty(target, name, {
+        value: createEnum(info),
+      });
+      break;
     case GIInfoType.FLAGS:
     case GIInfoType.OBJECT:
     case GIInfoType.STRUCT:

--- a/src/overrides/GLib.ts
+++ b/src/overrides/GLib.ts
@@ -1,0 +1,12 @@
+// deno-lint-ignore-file no-explicit-any
+function addErrorTag(GLib: any) {
+  Object.defineProperty(GLib.Error.prototype, Symbol.toStringTag, {
+    get() {
+      return this.message;
+    },
+  });
+}
+
+export function _init(GLib: any) {
+  addErrorTag(GLib);
+}

--- a/src/overrides/mod.ts
+++ b/src/overrides/mod.ts
@@ -1,4 +1,5 @@
 import * as GObject from "./GObject.ts";
+import * as GLib from "./GLib.ts";
 
 export interface GIOverride {
   name: string;
@@ -9,6 +10,7 @@ export interface GIOverride {
 
 export const overrides: GIOverride[] = [
   { name: "GObject", version: "2.0", module: GObject },
+  { name: "GLib", version: "2.0", module: GLib },
 ];
 
 export function hasOverride(namespace: string, version: string) {

--- a/src/types/interface.js
+++ b/src/types/interface.js
@@ -1,5 +1,5 @@
 import g from "../bindings/mod.js";
-import { getName } from "../utils/string.ts";
+import { getDisplayName } from "../utils/string.ts";
 import { handleCallable } from "./callable.js";
 import { handleProp } from "./prop.js";
 import { handleSignal } from "./signal.js";
@@ -48,10 +48,11 @@ function defineProps(target, info) {
 }
 
 export function createInterface(info, gType) {
-  const ObjectClass = class {};
+  const ObjectClass = class {
+  };
 
   Object.defineProperty(ObjectClass, "name", {
-    value: getName(info),
+    value: getDisplayName(gType),
   });
 
   Reflect.defineMetadata("gi:gtype", gType, ObjectClass);

--- a/src/types/object.js
+++ b/src/types/object.js
@@ -1,5 +1,5 @@
 import g from "../bindings/mod.js";
-import { getName } from "../utils/string.ts";
+import { getDisplayName } from "../utils/string.ts";
 import { handleCallable, handleStructCallable } from "./callable.js";
 import { objectByInfo } from "../utils/gobject.js";
 import { handleSignal } from "./signal.js";
@@ -121,7 +121,7 @@ export function createObject(info, gType) {
   Reflect.defineMetadata("gi:gtype", gType, ObjectClass);
 
   Object.defineProperty(ObjectClass, "name", {
-    value: getName(info),
+    value: getDisplayName(info),
   });
 
   defineMethods(ObjectClass, info);

--- a/src/types/struct.js
+++ b/src/types/struct.js
@@ -1,6 +1,6 @@
 import g from "../bindings/mod.js";
 import { cast_buf_ptr } from "../base_utils/convert.ts";
-import { getName } from "../utils/string.ts";
+import { getDisplayName } from "../utils/string.ts";
 import { handleCallable } from "./callable.js";
 import { handleField } from "./field.js";
 
@@ -36,7 +36,7 @@ export function createStruct(info, gType) {
   };
 
   Object.defineProperty(ObjectClass, "name", {
-    value: getName(info),
+    value: getDisplayName(info),
   });
 
   Reflect.defineMetadata("gi:gtype", gType, ObjectClass);

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -15,3 +15,7 @@ export function getName(info: Deno.PointerValue) {
 
   return name;
 }
+
+export function getDisplayName(info: Deno.PointerValue) {
+  return g.base_info.get_namespace(info) + "." + g.base_info.get_name(info);
+}


### PR DESCRIPTION
> [!NOTE]
> Depends on #30 

This PR will effectively cache all error enums from GI, and reuse them to provide useful error information when an error happens.

For example, given this code:

```js
import { require } from "./mod.ts";

const GLib = require("GLib", null);
GLib.fileGetContents("lmaoworld");
```

Before (with #30) applied:

![image](https://github.com/ahgilak/deno_gi/assets/37999241/0b3351c9-4831-4c2d-839d-b64fa4394709)

After:

![image](https://github.com/ahgilak/deno_gi/assets/37999241/cb4f9567-db5a-4a38-996f-e31255e8af36)

`deno_gi` will correctly identify that the error is a `GLib.FileError` and will provide the error messages when the error is being logged.