### PR TITLE
Fix Regressions about using `snake_case` instead of `camelCase`

### DIFF
--- a/examples/manual_loop.ts
+++ b/examples/manual_loop.ts
@@ -7,7 +7,7 @@ const context = GLib.MainContext.default();
 let isRunning = true;
 
 const win = Gtk.Window.new();
-win.setDefaultSize(400, 200);
+win.set_default_size(400, 200);
 win.connect("destroy", () => isRunning = false);
 win.present();
 

--- a/src/types/interface.js
+++ b/src/types/interface.js
@@ -52,7 +52,7 @@ export function createInterface(info, gType) {
   };
 
   Object.defineProperty(ObjectClass, "name", {
-    value: getDisplayName(gType),
+    value: getDisplayName(info),
   });
 
   Reflect.defineMetadata("gi:gtype", gType, ObjectClass);


### PR DESCRIPTION
Fixes a regression where there was incorrect usage of `getDisplayName` and fixes an oversight where I forgot to convert the `manual_loop.ts` example